### PR TITLE
petsc 3.20, allow host version pinning / migration

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -14,16 +14,22 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
+hdf5:
+- 1.14.2
 mpi:
 - mpich
 mpich:
 - '4'
 openmpi:
 - '4'
+petsc:
+- '3.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -14,16 +14,22 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
+hdf5:
+- 1.14.2
 mpi:
 - openmpi
 mpich:
 - '4'
 openmpi:
 - '4'
+petsc:
+- '3.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/migrations/petsc320.yaml
+++ b/.ci_support/migrations/petsc320.yaml
@@ -1,0 +1,13 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1696056741.0668209
+petsc:
+- '3.20'
+petsc4py:
+- '3.20'
+slepc:
+- '3.20'
+slepc4py:
+- '3.20'

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -12,10 +12,14 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
+hdf5:
+- 1.14.2
 llvm_openmp:
 - '16'
 macos_machine:
@@ -26,6 +30,8 @@ mpich:
 - '4'
 openmpi:
 - '4'
+petsc:
+- '3.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -12,10 +12,14 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
+hdf5:
+- 1.14.2
 llvm_openmp:
 - '16'
 macos_machine:
@@ -26,6 +30,8 @@ mpich:
 - '4'
 openmpi:
 - '4'
+petsc:
+- '3.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_mpimpich.yaml
+++ b/.ci_support/osx_arm64_mpimpich.yaml
@@ -12,10 +12,14 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
+hdf5:
+- 1.14.2
 llvm_openmp:
 - '16'
 macos_machine:
@@ -26,6 +30,8 @@ mpich:
 - '4'
 openmpi:
 - '4'
+petsc:
+- '3.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpi.yaml
@@ -12,10 +12,14 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
+hdf5:
+- 1.14.2
 llvm_openmp:
 - '16'
 macos_machine:
@@ -26,6 +30,8 @@ mpich:
 - '4'
 openmpi:
 - '4'
+petsc:
+- '3.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ outputs:
     test:
       commands:
         - export OMPI_MCA_plm=isolated
-        - export OMPI_MCA_btl_vader_single_copy_mechanism=none
+        - export OMPI_MCA_btl=tcp,self
         - export OMP_NUM_THREADS=2
         - if [ $CONDA_BUILD_CROSS_COMPILATION != '1' ]; then mpirun -np 2 DAMASK_grid --help; fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_number = 6 %}
+{% set build_number = 7 %}
 {% set version = "3.0.0-alpha7" %}
 {% set version_python = "3.0.0a7" %}
 {% set sha256 = "442b06b824441293e72ff91b211a555c5d497aedf62be1c4332c426558b848a4" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,9 +45,12 @@ outputs:
         - openmpi  # [mpi == 'openmpi' and build_platform != target_platform]
       host:
         - {{ mpi }}
+        - petsc
         - petsc * real_*
+        - hdf5
         - hdf5 * mpi_{{ mpi }}_*
         - libfyaml
+        - fftw
         - fftw * mpi_{{ mpi }}_*
       run:
         - hypre
@@ -79,7 +82,9 @@ outputs:
         - openmpi  # [mpi == 'openmpi' and build_platform != target_platform]
       host:
         - {{ mpi }}
+        - petsc
         - petsc * real_*
+        - hdf5
         - hdf5 * mpi_{{ mpi }}_*
         - libfyaml
       run:


### PR DESCRIPTION
- duplicate build-pinned dependencies, so that conda-build pinning can occur (`version=*` opts out of version pinning in conda_build_config, so any package that needs a build pin, such as an mpi variant, must be present twice - once with no version pin, once with `*` and the variant pin)
- add petsc 3.20 migration, since the bot migrator failed
- update openmpi environment variables [ref](https://github.com/conda-forge/petsc-feedstock/pull/171#pullrequestreview-1664262821)